### PR TITLE
Fix GitHub Actions buildx cache export issue

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -19,6 +19,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set lowercase repository owner
+        run: |
+          echo "REPOSITORY_OWNER_LOWERCASE=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
       - name: Log in to the GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -32,7 +39,7 @@ jobs:
           context: .
           file: ./backend/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ghcr.io/${{ github.repository_owner }}/graphrag-api:${{ github.sha }}
+          tags: ghcr.io/${{ env.REPOSITORY_OWNER_LOWERCASE }}/graphrag-api:${{ github.sha }}
           cache-from: type=gha,scope=api
           cache-to: type=gha,scope=api,mode=max
 
@@ -42,6 +49,6 @@ jobs:
           context: .
           file: ./frontend/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ghcr.io/${{ github.repository_owner }}/graphrag-frontend:${{ github.sha }}
+          tags: ghcr.io/${{ env.REPOSITORY_OWNER_LOWERCASE }}/graphrag-frontend:${{ github.sha }}
           cache-from: type=gha,scope=frontend
           cache-to: type=gha,scope=frontend,mode=max 


### PR DESCRIPTION
- Add docker/setup-buildx-action to enable cache export support
- Convert repository owner to lowercase for Docker registry compatibility
- Update image tags to use lowercase repository owner